### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Change Log
 Usage
 -----
 
-##EN
+## EN
 
 * Make sure your Android device is rooted with Xposed Framework installed.
 
@@ -48,7 +48,7 @@ Usage
 
 * By default, the generated JSON file is ```moments_output.json``` located in the root directory of the external storage.
 
-##ZH
+## ZH
 
 * 确认安卓设备已root并安装好Xposed框架。
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
